### PR TITLE
Update project setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@ and back to help with poking at the binary.
 
 1. Install Python 3.6
 2. pip install -r requirements.txt
-3. Run! eg. python -m omftools.af_compile -h
+3. Run! eg. python -m omftools.cli.af_compile -h

--- a/README.md
+++ b/README.md
@@ -5,6 +5,6 @@ and back to help with poking at the binary.
 
 ## Installation
 
-1. Install Python 3.5
+1. Install Python 3.6
 2. pip install -r requirements.txt
 3. Run! eg. python -m omftools.af_compile -h

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+dataclasses==0.7
 pillow==7.2.0
 validx==0.6.1
 jinja2==2.11.2


### PR DESCRIPTION
This pull request fixes several issues that crop up while trying to follow the instructions in the README.

1. Update version of Python to 3.6
When trying to `pip install -r requirements.txt`, pip will show this message:

> DEPRECATION: Python 3.5 reached the end of its life on September 13th, 2020. Please upgrade your Python as Python 3.5 is no longer maintained. pip 21.0 will drop support for Python 3.5 in January 2021. pip 21.0 will remove support for this functionality.

also

> ERROR: Could not find a version that satisfies the requirement black==19.10b0 (from -r requirements.txt (line 8)) (from versions: none)
ERROR: No matching distribution found for black==19.10b0 (from -r requirements.txt (line 8))

The setup.py of black 19.10b0 states
> python_requires=">=3.6"

2. Add dataclasses to requirements.txt
Running `python -m omftools.cli.generate_html /home/tech/omf/OMF97 output`
throws an error:

> Traceback (most recent call last):
  File "/home/tech/anaconda3/envs/omf/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/home/tech/anaconda3/envs/omf/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/tech/Dokumente/Projekte/pyomftools-master/omftools/cli/generate_html.py", line 6, in <module>
    from dataclasses import dataclass
ModuleNotFoundError: No module named 'dataclasses'

Solution: `pip install dataclasses==0.7`

3. Update Python example in README

af_compile and related files were moved to the cli module in commit 54a4e45c052ebf8c5f2c8dcbdf43ef039c04e168

The call becomes
`python -m omftools.cli.af_compile -h`

